### PR TITLE
Fix go build failure due to invalid go.mod go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cw-sakamoto/kibertas
 
-go 1.21.3
+go 1.21
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.22.1


### PR DESCRIPTION
Fixes this error on go-build: `kibertas/go.mod:3: invalid go version 1.21.3: must match format 1.23`