### PR TITLE
Use goreleaser and GitHub Actions for image publishing to ghcr.io

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,60 @@
+name: Release
+
+on:
+  push:
+
+permissions:
+  # For uploading artifacts
+  contents: write
+  # For publishing images to ghcr.io
+  packages: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        run: echo "flags=--snapshot" >> $GITHUB_ENV
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21.3'
+          cache: true
+      -
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean ${{ env.flags }}
+        env:
+          REGISTRY: ghcr.io/chatwork
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Upload assets
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: kibertas
+          path: |
+            dist/kibertas*.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ kibertas
 manifests/credentials.yaml
 .bin/
 .vscode
+dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,9 @@
-FROM golang:1.21 AS builder
-
-ENV CGO_ENABLED=0
-
-WORKDIR /app
-
-COPY go.mod /app
-COPY go.sum /app
-
-RUN go mod download
-
-COPY . .
-
-RUN go build -o kibertas .
-
 FROM gcr.io/distroless/static-debian12
 #FROM amazon/aws-cli:latest
 
 ARG TARGETOS
 ARG TARGETARCH
 
-COPY --from=builder /app/kibertas /usr/local/bin/kibertas
+COPY kibertas /usr/local/bin/kibertas
 
 ENTRYPOINT ["/usr/local/bin/kibertas"]

--- a/Makefile
+++ b/Makefile
@@ -32,9 +32,12 @@ lint:
 test:
 	go test -timeout 6m -v ./...
 
+# This will produce following images for testing locally:
+# - examplecom/kibertas:canary-arm64
+# - examplecom/kibertas:canary-amd64
 .PHONY: goreleaser-snapshot
 goreleaser-snapshot:
-	curl -sfL https://goreleaser.com/static/run | bash -s -- --release --clean --snapshot
+	curl -sfL https://goreleaser.com/static/run | REGISTRY=examplecom bash -s -- --clean --snapshot
 
 .PHONY: create-kind
 create-kind:

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -1,0 +1,70 @@
+project_name: kibertas
+env:
+builds:
+  - id: kibertas
+    main: ./
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+    goos:
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm64
+      - "386"
+changelog:
+  use: github-native
+
+release:
+  prerelease: auto
+
+dockers:
+  # https://goreleaser.com/customization/docker/
+  - use: buildx
+    goos: linux
+    goarch: amd64
+    image_templates:
+      - "{{ .Env.REGISTRY }}/{{ .ProjectName }}:canary-amd64"
+      - "{{ .Env.REGISTRY }}/{{ .ProjectName }}:{{ .Version }}-amd64"
+      - "{{ .Env.REGISTRY }}/{{ .ProjectName }}:{{ .Major }}-amd64"
+      - "{{ .Env.REGISTRY }}/{{ .ProjectName }}:{{ .Major }}.{{ .Minor }}-amd64"
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+  - use: buildx
+    goos: linux
+    goarch: arm64
+    image_templates:
+      - "{{ .Env.REGISTRY }}/{{ .ProjectName }}:canary-arm64"
+      - "{{ .Env.REGISTRY }}/{{ .ProjectName }}:{{ .Version }}-arm64"
+      - "{{ .Env.REGISTRY }}/{{ .ProjectName }}:{{ .Major }}-arm64"
+      - "{{ .Env.REGISTRY }}/{{ .ProjectName }}:{{ .Major }}.{{ .Minor }}-arm64"
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+
+docker_manifests:
+  - name_template: "{{ .Env.REGISTRY }}/{{ .ProjectName }}:canary"
+    image_templates:
+      - "{{ .Env.REGISTRY }}/{{ .ProjectName }}:canary-amd64"
+      - "{{ .Env.REGISTRY }}/{{ .ProjectName }}:canary-arm64"
+  - name_template: "{{ .Env.REGISTRY }}/{{ .ProjectName }}:{{ .Version }}"
+    image_templates:
+      - "{{ .Env.REGISTRY }}/{{ .ProjectName }}:{{ .Version }}-amd64"
+      - "{{ .Env.REGISTRY }}/{{ .ProjectName }}:{{ .Version }}-arm64"
+  - name_template: "{{ .Env.REGISTRY }}/{{ .ProjectName }}:{{ .Major }}"
+    image_templates:
+      - "{{ .Env.REGISTRY }}/{{ .ProjectName }}:{{ .Major }}-amd64"
+      - "{{ .Env.REGISTRY }}/{{ .ProjectName }}:{{ .Major }}-arm64"
+  - name_template: "{{ .Env.REGISTRY }}/{{ .ProjectName }}:{{ .Major }}.{{ .Minor }}"
+    image_templates:
+      - "{{ .Env.REGISTRY }}/{{ .ProjectName }}:{{ .Major }}.{{ .Minor }}-amd64"
+      - "{{ .Env.REGISTRY }}/{{ .ProjectName }}:{{ .Major }}.{{ .Minor }}-arm64"


### PR DESCRIPTION
As the title says :)

I think we don't need to set up anything to make this workflow work.
GitHub Actions, along with the `permissions` specified in the workflow, would give us access to ghcr.io and therefore the image publishing should just work.

The images should be "private" by default. No action should be needed by you to hide the images.