### PR TITLE
Add E2E testing GHA workflow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,33 @@
+name: E2E test
+on:
+  push:
+    branches: [ main ]
+    tags:
+      - v*
+  pull_request:
+    branches:
+    - 'main'
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+
+jobs:
+  publish:
+    if: github.repository_owner == vars.REPO_OWNER
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+          role-to-assume: ${{ secrets.IAM_ROLE_ARN}}
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21.3'
+          check-latest: true
+      - name: Run E2E tests
+        run: make e2e

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,11 @@ lint:
 
 .PHONY: test
 test:
-	go test -timeout 6m -v ./...
+	go test -timeout 6m -short -v ./...
+
+.PHONY: e2e
+e2e:
+	go test -timeout 45m -v ./...
 
 # This will produce following images for testing locally:
 # - examplecom/kibertas:canary-arm64


### PR DESCRIPTION
Although GHA does not expose secrets to public forks, we make extra sure that no public forks can attack our GHA and AWS accounts :)

We make it to run on:

- Every push to the main
- Every pull request coming from this repository
- Every workflow dispatch (which can be triggered only by ourselves)
# Prerequisites

1. We need an IAM role with enough permissions to run the tests, with the following trust relationship.
Note that you need to replace AWS_ACCOUNT with your AWS account ID:

```
{
  "Version": "2008-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Principal": {
        "Federated": "arn:aws:iam::${AWS_ACCOUNT}:oidc-provider/token.actions.githubusercontent.com"
      },
      "Action": "sts:AssumeRoleWithWebIdentity",
      "Condition": {
        "StringLike": {
          "token.actions.githubusercontent.com:sub": "repo:chatwork/kibertas"
        }
      }
    }
  ]
}
```

2. Set GHA secrets and variables below:

Secrets:

- AWS_DEFAULT_REGION
- IAM_ROLE_ARN (points to the role created above)

Variables:

- REPO_OWNER (Set to `chatwork` for us. Forks would have different values to enable testing workflows before submitting PRs to us)