### PR TITLE
Reorganize tests into three groups

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   test:
+    environment: test
     runs-on: ubuntu-latest
     timeout-minutes: 6
     steps:
@@ -29,6 +30,7 @@ jobs:
       - name: Run tests
         run: make test
   kindtest:
+    environment: test
     strategy:
       matrix:
         kind_image:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,12 +14,46 @@ concurrency:
 
 jobs:
   test:
-    environment: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 6
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21.3'
+          check-latest: true
+      - name: Run tests
+        run: make test
+  kindtest:
     strategy:
       matrix:
         kind_image:
         - "kindest/node:v1.29.8@sha256:d46b7aa29567e93b27f7531d258c372e829d7224b25e3fc6ffdefed12476d3aa"
         - "kindest/node:v1.30.4@sha256:976ea815844d5fa93be213437e3ff5754cd599b040946b5cca43ca45c2047114"
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21.3'
+          check-latest: true
+      - name: Install cloud-provider-kind
+        run: make cloud-provider-kind
+      - name: Run E2E tests on kind
+        run: make e2e/kindtest
+        env:
+          KIND_IMAGE: ${{ matrix.kind_image }}
+  ekstest:
+    environment: test
     runs-on: ubuntu-latest
     # Have enough timeout for `make e2e`
     # which requires up to 45 minutes to run.
@@ -34,16 +68,8 @@ jobs:
         with:
           go-version: '1.21.3'
           check-latest: true
-      - name: Install cloud-provider-kind
-        run: make cloud-provider-kind
-      - name: Run tests
-        run: make test
-      # In near future, we might want to run this
-      # only when triggered manually or on a schedule.
-      - name: Run E2E tests
-        run: make e2e
-        env:
-          KIND_IMAGE: ${{ matrix.kind_image }}
+      - name: Run E2E tests on EKS
+        run: make e2e/ekstest
   golangci:
     name: lint
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,15 @@ lint:
 
 .PHONY: test
 test:
-	go test -short -timeout 6m -v ./...
+	go test -timeout 6m -v ./util/... ./config/...
 
-.PHONY: e2e
-e2e:
-	go test -timeout 45m -v ./...
+.PHONY: e2e/kindtest
+e2e/kindtest:
+	go test -timeout 20m -v ./cmd/...
+
+.PHONY: e2e/ekstest
+e2e/ekstest:
+	go test -timeout 55m -v ./cmd/... -tags=ekstest
 
 # This will produce following images for testing locally:
 # - examplecom/kibertas:canary-arm64

--- a/cmd/cert-manager/cert-manager_test.go
+++ b/cmd/cert-manager/cert-manager_test.go
@@ -1,3 +1,5 @@
+//go:build !ekstest
+
 package certmanager
 
 import (

--- a/cmd/cluster-autoscaler/cluster_autoscaler_test.go
+++ b/cmd/cluster-autoscaler/cluster_autoscaler_test.go
@@ -1,3 +1,5 @@
+//go:build ekstest
+
 package clusterautoscaler
 
 import (

--- a/cmd/cluster-autoscaler/karpenter_test.go
+++ b/cmd/cluster-autoscaler/karpenter_test.go
@@ -1,3 +1,5 @@
+//go:build ekstest
+
 package clusterautoscaler
 
 import (

--- a/cmd/datadog-agent/datadog-agent_test.go
+++ b/cmd/datadog-agent/datadog-agent_test.go
@@ -1,3 +1,5 @@
+//go:build !ekstest
+
 package datadogagent
 
 import (

--- a/cmd/fluent/fluent_test.go
+++ b/cmd/fluent/fluent_test.go
@@ -1,3 +1,5 @@
+//go:build ekstest
+
 package fluent
 
 import (

--- a/cmd/ingress/ingress_test.go
+++ b/cmd/ingress/ingress_test.go
@@ -1,3 +1,5 @@
+//go:build !ekstest
+
 package ingress
 
 import (


### PR DESCRIPTION
To prevent tests against EKS from interfering with each other, we (re)organize tests into three groups and their respective jobs:

- `kindtest`: Tests that are build-tagged `!ekstest` under ./cmd, run against multiple kind versions
- `ekstest`: Tests that are build-tagged `ekstest` under ./cmd, run against EKS cluster
- everything else: run locally (within the runner, without kind and EKS)
