### PR TITLE
e2e: Fix fluentd test for AL2023, and for CI using OIDC

### DIFF
--- a/cmd/fluent/testdata/fluentd-alter-log-dir.pod.yaml
+++ b/cmd/fluent/testdata/fluentd-alter-log-dir.pod.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: fluentd-alter-log-dir
+spec:
+  containers:
+  - name: aws-cli
+    image: amazon/aws-cli
+    command: ["sh", "-c", "mkdir -p /var/log/fluentd-s3 && chown -R 999:999 /var/log/fluentd-s3 && mkdir -p /var/log/fluentd && chown -R 999:999 /var/log/fluentd"]
+    volumeMounts:
+    - name: fluentd-log-dir
+      mountPath: /var/log/fluentd-s3
+  volumes:
+  - name: fluentd-log-dir
+    hostPath:
+      path: /var/log
+      type: DirectoryOrCreate
+  restartPolicy: Never

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/cert-manager/cert-manager v1.15.3
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/miekg/dns v1.1.62
-	github.com/mumoshu/testkit v0.10.0
+	github.com/mumoshu/testkit v0.11.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/mumoshu/testkit v0.10.0 h1:F/m0/fUzgzf9dgdA4vqj0Bjcw98b4U1iSfaybYWWrVU=
-github.com/mumoshu/testkit v0.10.0/go.mod h1:UIqn/rsr4ziNdnV7rY/idcYrcpE9n19H10Xhwt8vLqk=
+github.com/mumoshu/testkit v0.11.0 h1:lzBEWkIxs6PnI/VGHiV/4L8eA+cOvYu2/LYSKnovCng=
+github.com/mumoshu/testkit v0.11.0/go.mod h1:UIqn/rsr4ziNdnV7rY/idcYrcpE9n19H10Xhwt8vLqk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/onsi/ginkgo/v2 v2.19.0 h1:9Cnnf7UHo57Hy3k6/m5k3dRfGTMXGvxhHFvkDTCTpvA=


### PR DESCRIPTION
This fixes the E2E test for the fluentd checker to work with AL2023-based managed node groups by explicitly setting `http_put_response_hop_limit`.

This also fixes the issue on CI where you can't persist the tfstate(!). The default tf project assumes you use S3 backend now. The terraform `backend-config` like the bucket name and the object key for the tfstate should be provided via envvars.