### PR TITLE
Manage ingress-nginx dependencies using Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
+- package-ecosystem: "docker"
+  directories:
+  - "/thirdparty/*"
+  schedule:
+    interval: "weekly"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ KIND_VERSION = 0.21.0
 KUBERNETES_VERSION = 1.29.1
 KIND_NODE_HASH = a0cc28af37cf39b019e2b448c54d1a3f789de32536cb5a5db61a49623e527144
 CERT_MANAGER_VERSION = 1.14.1
-INGRESS_NGINX_VERSION = 1.9.4
+INGRESS_NGINX_VERSION = $(shell grep "FROM registry.k8s.io/ingress-nginx/controller:" thirdparty/ingress-nginx/Dockerfile| cut -d':' -f2)
 
 GOLANGCI_LINT_VERSION=1.55.1
 TAG  ?= $(shell git describe --tags --abbrev=0 HEAD || echo dev)
@@ -84,13 +84,13 @@ delete-kind:
 
 .PHONY: apply-ingress-nginx
 apply-ingress-nginx:
-	@kubectl apply --wait=true -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v${INGRESS_NGINX_VERSION}/deploy/static/provider/cloud/deploy.yaml
+	@kubectl apply --wait=true -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-${INGRESS_NGINX_VERSION}/deploy/static/provider/cloud/deploy.yaml
 	@sleep 2
 	@kubectl -n ingress-nginx wait deploy -l app.kubernetes.io/instance=ingress-nginx --for=condition=available --timeout=60s
 
 .PHONY: delete-ingress-nginx
 delete-ingress-nginx:
-	@kubectl delete --wait=true -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v${INGRESS_NGINX_VERSION}/deploy/static/provider/cloud/deploy.yaml
+	@kubectl delete --wait=true -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-${INGRESS_NGINX_VERSION}/deploy/static/provider/cloud/deploy.yaml
 
 .PHONY: apply-cert-manager
 apply-cert-manager:

--- a/thirdparty/Chart.yaml
+++ b/thirdparty/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: thirdparty
+version: 0.1.0
+dependencies:
+- name: ingress-nginx
+  version: 4.12.1
+  repository: https://kubernetes.github.io/ingress-nginx

--- a/thirdparty/ingress-nginx/Dockerfile
+++ b/thirdparty/ingress-nginx/Dockerfile
@@ -1,0 +1,1 @@
+FROM registry.k8s.io/ingress-nginx/controller:v1.12.1


### PR DESCRIPTION
This attempts to manage one of our third-party container image dependencies (ingress-nginx) using Dependabot via [the fake dockerfile pattern](https://taeguk.co.uk/blog/using-dependabot-to-maintain-docker-image-dependencies/).

To prepare for further progress, I've also added a "fake Chart.yaml" which is intended to list all the chart dependencies. It will enable us to automate chart dependency management via Dependabot once https://github.com/dependabot/dependabot-core/pull/11726 lands GitHub Dependabot.