### PR TITLE
Use dependabot for updating chart dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,7 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
+- package-ecosystem: "helm"
+  directory: "/thirdparty"
+  schedule:
+    interval: "weekly"


### PR DESCRIPTION
As forecasted in https://github.com/chatwork/kibertas/pull/168, let's use recently added GitHub Dependabot Helm support for managing chart dependencies, which will be used in our E2E test suite.