### PR TITLE
Use up-to-date ingress-nginx for E2E testing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,10 +12,11 @@ require (
 	github.com/cert-manager/cert-manager v1.15.3
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/miekg/dns v1.1.62
-	github.com/mumoshu/testkit v0.11.0
+	github.com/mumoshu/testkit v0.13.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.9.0
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.31.1
 	k8s.io/apimachinery v0.31.1
 	k8s.io/client-go v0.31.1
@@ -104,7 +105,6 @@ require (
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.31.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/mumoshu/testkit v0.11.0 h1:lzBEWkIxs6PnI/VGHiV/4L8eA+cOvYu2/LYSKnovCng=
-github.com/mumoshu/testkit v0.11.0/go.mod h1:UIqn/rsr4ziNdnV7rY/idcYrcpE9n19H10Xhwt8vLqk=
+github.com/mumoshu/testkit v0.13.0 h1:CZD/eWGx0R8eWErBiIYtDkP9adkCgGvFGq6/dyFYSR0=
+github.com/mumoshu/testkit v0.13.0/go.mod h1:UIqn/rsr4ziNdnV7rY/idcYrcpE9n19H10Xhwt8vLqk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/onsi/ginkgo/v2 v2.19.0 h1:9Cnnf7UHo57Hy3k6/m5k3dRfGTMXGvxhHFvkDTCTpvA=

--- a/internal/ktesting/load_helm_chart_meta.go
+++ b/internal/ktesting/load_helm_chart_meta.go
@@ -1,0 +1,45 @@
+package ktesting
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v2"
+)
+
+type HelmChartMeta struct {
+	Name         string                `yaml:"name"`
+	Version      string                `yaml:"version"`
+	Dependencies []HelmChartDependency `yaml:"dependencies"`
+}
+
+type HelmChartDependency struct {
+	Name    string `yaml:"name"`
+	Version string `yaml:"version"`
+}
+
+func LoadHelmChartMeta(chartPath string) (*HelmChartMeta, error) {
+	chartMeta := &HelmChartMeta{}
+
+	yamlFile, err := os.ReadFile(chartPath)
+	if err != nil {
+		return nil, err
+	}
+
+	err = yaml.Unmarshal(yamlFile, chartMeta)
+	if err != nil {
+		return nil, err
+	}
+
+	return chartMeta, nil
+}
+
+func (h *HelmChartMeta) GetVersion(name string) (string, error) {
+	for _, dependency := range h.Dependencies {
+		if dependency.Name == name {
+			return dependency.Version, nil
+		}
+	}
+
+	return "", fmt.Errorf("dependency %s not found", name)
+}


### PR DESCRIPTION
This helps us testing latest ingress-nginx on our environments before making it into production.

Ref #168