### PR TITLE
fix: remove vendor references from default values

### DIFF
--- a/cmd/fluent/fluent.go
+++ b/cmd/fluent/fluent.go
@@ -50,9 +50,9 @@ func NewFluent(checker *cmd.Checker) (*Fluent, error) {
 
 	resourceName := "burst-log-generator"
 
-	env := "cwtest"
+	env := "test"
 
-	logBucketName := "cwtest-kubernetes-logs"
+	logBucketName := "kubernetes-logs"
 
 	if v := os.Getenv("RESOURCE_NAME"); v != "" {
 		resourceName = v

--- a/cmd/ingress/ingress.go
+++ b/cmd/ingress/ingress.go
@@ -52,7 +52,7 @@ func NewIngress(checker *cmd.Checker, noDnsCheck bool) (*Ingress, error) {
 	checker.Chatwork.AddMessage(fmt.Sprintf("Ingress check application Namespace: %s\n", namespace))
 
 	resourceName := "sample"
-	externalHostName := "sample-skmt.cwtest.info"
+	externalHostName := "example.local"
 	ingressClassName := "alb"
 
 	if v := os.Getenv("RESOURCE_NAME"); v != "" {


### PR DESCRIPTION
## Background
This project contains hardcoded vendor-specific default values (e.g., "cwtest") that were remnants from initial development. As an OSS project, these internal references should be replaced with generic values to avoid exposing vendor names to users.

## What I did
- Replaced "cwtest" with "test" in fluent module environment defaults
- Replaced "cwtest-kubernetes-logs" with "kubernetes-logs" in fluent module bucket defaults  
- Replaced "sample-skmt.cwtest.info" with "example.local" in ingress module hostname defaults
