### PR TITLE
chore: Remove ekstest job from CI and clean up build tags

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,26 +54,6 @@ jobs:
         run: make e2e/kindtest
         env:
           KIND_IMAGE: ${{ matrix.kind_image }}
-  ekstest:
-    environment: test
-    runs-on: ubuntu-latest
-    # Have enough timeout for `make e2e`
-    # which requires up to 45 minutes to run.
-    timeout-minutes: 55
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-      - name: Install terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
-      - name: Set up Go
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
-        with:
-          go-version: '1.21.3'
-          check-latest: true
-      - name: Run E2E tests on EKS
-        run: make e2e/ekstest
   golangci:
     name: lint
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -36,9 +36,6 @@ test:
 e2e/kindtest:
 	go test -timeout 20m -v ./cmd/...
 
-.PHONY: e2e/ekstest
-e2e/ekstest:
-	go test -timeout 55m -v ./cmd/... -tags=ekstest
 
 # This will produce following images for testing locally:
 # - examplecom/kibertas:canary-arm64

--- a/cmd/cert-manager/cert-manager_test.go
+++ b/cmd/cert-manager/cert-manager_test.go
@@ -1,5 +1,3 @@
-//go:build !ekstest
-
 package certmanager
 
 import (

--- a/cmd/cluster-autoscaler/cluster_autoscaler_test.go
+++ b/cmd/cluster-autoscaler/cluster_autoscaler_test.go
@@ -1,5 +1,3 @@
-//go:build !ekstest
-
 package clusterautoscaler
 
 import (

--- a/cmd/datadog-agent/datadog-agent_test.go
+++ b/cmd/datadog-agent/datadog-agent_test.go
@@ -1,5 +1,3 @@
-//go:build !ekstest
-
 package datadogagent
 
 import (

--- a/cmd/fluent/fluent_test.go
+++ b/cmd/fluent/fluent_test.go
@@ -1,5 +1,3 @@
-//go:build !ekstest
-
 package fluent
 
 import (

--- a/cmd/ingress/ingress_test.go
+++ b/cmd/ingress/ingress_test.go
@@ -1,5 +1,3 @@
-//go:build !ekstest
-
 package ingress
 
 import (


### PR DESCRIPTION
## Context
- We decided to only run Kind-based tests in GitHub Actions, so the EKS test job has been removed.

## Summary
- Removed ekstest job from GitHub Actions workflow
- Removed `!ekstest` build constraints from test files
- Removed ekstest target from Makefile

## Changes
- `.github/workflows/test.yaml`: Removed ekstest job
- `Makefile`: Removed e2e/ekstest target
- `cmd/*/*.test.go`: Removed `//go:build !ekstest` constraints (these were excluding tests when ekstest tag was set)