### PR TITLE
Ensure unique KubernetesCluster per test

### DIFF
--- a/cmd/cluster-autoscaler/cluster_autoscaler_test.go
+++ b/cmd/cluster-autoscaler/cluster_autoscaler_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/chatwork/kibertas/cmd"
+	"github.com/chatwork/kibertas/internal/ktesting"
 	"github.com/chatwork/kibertas/util/notify"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -35,7 +36,7 @@ func TestClusterAutoscalerScaleUpFromNonZero(t *testing.T) {
 		testkit.RetainResourcesOnFailure(),
 	)
 
-	kc := h.KubernetesCluster(t)
+	kc := h.KubernetesCluster(t, ktesting.WithRandomClusterID())
 
 	kctl := testkit.NewKubectl(kc.KubeconfigPath)
 

--- a/cmd/cluster-autoscaler/karpenter_test.go
+++ b/cmd/cluster-autoscaler/karpenter_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/chatwork/kibertas/cmd"
+	"github.com/chatwork/kibertas/internal/ktesting"
 	"github.com/chatwork/kibertas/util/notify"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -54,7 +55,7 @@ func TestKarpenterScaleUpFromNonZero(t *testing.T) {
 		testkit.RetainResourcesOnFailure(),
 	)
 
-	kc := h.KubernetesCluster(t)
+	kc := h.KubernetesCluster(t, ktesting.WithRandomClusterID())
 
 	k := testkit.NewKubernetes(kc.KubeconfigPath)
 	testkit.PollUntil(t, func() bool {

--- a/cmd/datadog-agent/datadog-agent_test.go
+++ b/cmd/datadog-agent/datadog-agent_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/chatwork/kibertas/cmd"
+	"github.com/chatwork/kibertas/internal/ktesting"
 	"github.com/chatwork/kibertas/util/notify"
 	"github.com/mumoshu/testkit"
 	"github.com/sirupsen/logrus"
@@ -99,7 +100,7 @@ func TestDatadogAgentCheckE2E(t *testing.T) {
 		testkit.RetainResourcesOnFailure(),
 	)
 
-	kc := h.KubernetesCluster(t)
+	kc := h.KubernetesCluster(t, ktesting.WithRandomClusterID())
 
 	helm := testkit.NewHelm(kc.KubeconfigPath)
 	// See https://github.com/kubernetes/autoscaler/tree/master/charts/cluster-autoscaler#tldr

--- a/cmd/fluent/fluent_test.go
+++ b/cmd/fluent/fluent_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/chatwork/kibertas/cmd"
+	"github.com/chatwork/kibertas/internal/ktesting"
 	"github.com/chatwork/kibertas/util/notify"
 	"github.com/stretchr/testify/require"
 
@@ -43,7 +44,7 @@ func TestFluentE2E(t *testing.T) {
 		testkit.RetainResourcesOnFailure(),
 	)
 
-	kc := h.KubernetesCluster(t)
+	kc := h.KubernetesCluster(t, ktesting.WithRandomClusterID())
 	ns := h.KubernetesNamespace(t, testkit.KubeconfigPath(kc.KubeconfigPath))
 	t.Cleanup(func() {
 		if t.Failed() {

--- a/cmd/ingress/ingress_test.go
+++ b/cmd/ingress/ingress_test.go
@@ -48,7 +48,7 @@ func TestIngressCheckE2E(t *testing.T) {
 		testkit.RetainResourcesOnFailure(),
 	)
 
-	kc := h.KubernetesCluster(t)
+	kc := h.KubernetesCluster(t, ktesting.WithRandomClusterID())
 	time.Sleep(240 * time.Second)
 
 	// Start cloud-provider-kind to manage service type=LoadBalancer

--- a/internal/ktesting/kubernetes_cluster_helper.go
+++ b/internal/ktesting/kubernetes_cluster_helper.go
@@ -1,0 +1,36 @@
+package ktesting
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+
+	"github.com/mumoshu/testkit"
+)
+
+const clusterIDLen = 5
+
+// WithRandomClusterID returns an option function that sets
+// a fixed-length random lowercase hex cluster ID (length=5).
+func WithRandomClusterID() func(c *testkit.KubernetesClusterConfig) {
+	return func(c *testkit.KubernetesClusterConfig) {
+		// Generate 3 random bytes -> 6 hex chars, then trim to 5.
+		id, err := randomHex(3)
+		if err != nil {
+			c.ID = "aaaaa" // safe fallback on error
+			return
+		}
+		if len(id) > clusterIDLen {
+			id = id[:clusterIDLen]
+		}
+		c.ID = id
+	}
+}
+
+// randomHex returns a hex string generated from n random bytes.
+func randomHex(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}


### PR DESCRIPTION
## Why

  When E2E tests run in parallel, multiple tests could share the same cluster if
  KubernetesCluster is invoked without a unique ID. 

## What
- Add internal/ktesting/WithRandomClusterID() returning
  func(*testkit.KubernetesClusterConfig).
- Replace all h.KubernetesCluster(t) call sites with
  h.KubernetesCluster(t, ktesting.WithRandomClusterID()).
- This applies specifically when using kind as the Kubernetes cluster provider.

## How

Generate a fixed-length 5-character lowercase hex ID using only the standard library:

  - crypto/rand → random bytes
  - encoding/hex → hex-encode
  - Trim to 5 chars for a predictable, short ID that avoids kind name limits.